### PR TITLE
Extract GitHub org and other Doctrine specifics to .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,29 @@ We are using the [Github Import API
 Beta](https://gist.github.com/jonmagic/5282384165e0f86ef105) to migrate issues
 from Jira via REST API to Github.
 
-Reasons for our move are the constant Spam Problems on our public Jira that we couldn't
-get under control and the amount of maintenance we have to put into Jira.
-
-Downsides of the migration are:
-
-- the lack of multi milestone support on Github
-- the lack of "good" search engine and filtering on Github issues
-- the general wonkyness of Github issues
-- no security issue support
-
 To keep all history we are importing issues from Jira.
 
 Configuration: Create a `.env` file with the following environment variables:
 
 ```
-JIRA_URL=http://server/path/to/jira
-JIRA_USER=foo
-JIRA_PASSWORD=bar
-GITHUB_USERNAME=name of the user importing the tickets
-GITHUB_TOKEN=token for the user, propably requires admin token with everything
+JIRA_URL=https://jira.atlassian.net/
+JIRA_USER=email@example.com
+JIRA_TOKEN=123456789
+GITHUB_USERNAME=sheldoncooper
+GITHUB_TOKEN=1234abcd5678edgh
+GITHUB_ORG=caltach
+
+ISSUE_TYPES=Epic,Bug,Task,Spike,Enhancement
+
+ASSIGNEES='{ "[accountId]": "sheldoncooper" }'
+
+PROJECTS='{ "AP": "awesome-project" }'
+
+CLOSED_STATES=Resolved,Closed,Done,Fixed,Løst
+
 ```
 
-This repository contains all the scripts necessary for the migration.
+This repository contains all the scripts necessary for the migration. Run in the following order, as `php version_to_milestones [PROJECT KEY]`:
 
 * `version_to_milestones.php` script to download all versions of a project and create equivalent
   milestones in Github Issue Tracker. It keeps a map of version-id/number to
@@ -35,9 +35,6 @@ This repository contains all the scripts necessary for the migration.
 * `export_jira_tickets.php` script to download all Jira issues per project and put them into a
   folder, one file per issue with the Github import API format. This
   script is using the Github milestones and labels as input.
-  **REQUIRES CHANGES** to the `$knownIssueTypes` and the `$knownAssigneesMap`
-  variables for mapping issue types to labels in a following step and assigning
-  the right Github users as creator or assignee of an issue.
 
 * `import_tickets.php` script to push all tickets to a Github import API queue and poll for
   status, assigning each downloaded jira issue its appropriate Github Issue ID.
@@ -52,23 +49,6 @@ This repository contains all the scripts necessary for the migration.
 * `assign_label.php` script to create labels according to Resolutions and Issue Types
   for a Jira Project in Github Issue tracker from the previously fetched import issue numbers.
 
-* `jira_versions_to_github_releases.php` script to pull all versions from Jira and prepare a list of releases to
-  create on Github, including release notes with adjusted ticket references and
-  then push them. This script creates a hashmap of Jira Version Id to Github
-  Release Id for future Redirects when Jira is decommissioned. **INCOMPLETE**
-
 * `generate-issues-map.php` script to pull all tickets from Github, extract the Jira Ticket Number
   from it and create a map of Jira Ticket Key to Github Id for future Redirects
   when Jira is decommissioned.
-
-Want to use this as external party? Things to watch out for:
-
-- There is some configuration code in `export_jira_tickets.php` that must be
-  adjusted.
-- Also in `export_jira_tickets.php` is commeted out code for handling inward
-  and outward links between tickets.  For us, the commented version currently
-  generates Markdown links to the Jira URLs, where we have redirects in place
-  to go to the Github issue.
-- The Markdown converter currently detects Doctrine Jira Project Keys and converts
-  them again to links to the old jira that then get redirected to the Github tracker
-  using a script on top of `generate-issues-map.php`, which also needs project key adjustments.

--- a/assign_label.php
+++ b/assign_label.php
@@ -23,8 +23,8 @@ if (!isset($projects[$project])) {
 
 $githubRepository = $projects[$project];
 $githubHeaders = [
-    'User-Agent: Doctrine Jira Migration',
-    'Authorization: token ' . $_SERVER['GITHUB_TOKEN'],
+    'User-Agent: ' . getenv('GITHUB_ORG') . ' Jira Migration',
+    'Authorization: token ' . getenv('GITHUB_TOKEN'])
     'Accept: application/vnd.github.golden-comet-preview+json'
 ];
 
@@ -51,10 +51,10 @@ foreach ($files as $file) {
         $githubId = $issueNumbers[$issueKey];
 
         $client->post(
-            'https://api.github.com/repos/doctrine/' . $githubRepository . '/issues/' . $githubId . '/labels',
+            'https://api.github.com/repos/' . getenv('GITHUB_ORG') . '/' . $githubRepository . '/issues/' . $githubId . '/labels',
             $githubHeaders,
             json_encode($issue['issue']['labels'])
         );
-        printf("https://github.com/doctrine/%s/issues/%d\n", $githubRepository, $githubId);
+        printf("https://github.com/%s/%s/issues/%d\n", getenv('GITHUB_ORG'), $githubRepository, $githubId);
     }
 }

--- a/assign_label.php
+++ b/assign_label.php
@@ -24,7 +24,7 @@ if (!isset($projects[$project])) {
 $githubRepository = $projects[$project];
 $githubHeaders = [
     'User-Agent: ' . getenv('GITHUB_ORG') . ' Jira Migration',
-    'Authorization: token ' . getenv('GITHUB_TOKEN'])
+    'Authorization: token ' . getenv('GITHUB_TOKEN'),
     'Accept: application/vnd.github.golden-comet-preview+json'
 ];
 

--- a/attachments.php
+++ b/attachments.php
@@ -50,7 +50,7 @@ foreach ($issues as $issue) {
     $attachments = scandir('data/attachments/' . $project . '/' . $issue);
 
     $gist = [
-        'description' => 'Attachments to ' . getenv('GITHUB_ORG') . ' Jira Issue ' . $issue . ' - https://github.com/' . getenv('GITHUB_ORG') '/' . $githubRepository . '/issues/' . $issueMap[$issue],
+        'description' => 'Attachments to ' . getenv('GITHUB_ORG') . ' Jira Issue ' . $issue . ' - https://github.com/' . getenv('GITHUB_ORG') . '/' . $githubRepository . '/issues/' . $issueMap[$issue],
         'public' => false,
         'files' => [],
     ];

--- a/attachments.php
+++ b/attachments.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Doctrine Jira to Github Migration
+ * Jira to Github Migration
  *
  * Import non-binary attachments into a Gist and comment on the relevant issue
  * with a link.
@@ -31,8 +31,8 @@ if (!isset($projects[$project])) {
 
 $githubRepository = $projects[$project];
 $githubHeaders = [
-    'User-Agent: Doctrine Jira Migration',
-    'Authorization: token ' . $_SERVER['GITHUB_TOKEN'],
+    'User-Agent: ' . getenv('GITHUB_ORG') . 'Jira Migration',
+    'Authorization: token ' . getenv('GITHUB_TOKEN'),
     'Accept: application/vnd.github.golden-comet-preview+json'
 ];
 
@@ -50,7 +50,7 @@ foreach ($issues as $issue) {
     $attachments = scandir('data/attachments/' . $project . '/' . $issue);
 
     $gist = [
-        'description' => 'Attachments to Doctrine Jira Issue ' . $issue . ' - https://github.com/doctrine/' . $githubRepository . '/issues/' . $issueMap[$issue],
+        'description' => 'Attachments to ' . getenv('GITHUB_ORG') . ' Jira Issue ' . $issue . ' - https://github.com/' . getenv('GITHUB_ORG') '/' . $githubRepository . '/issues/' . $issueMap[$issue],
         'public' => false,
         'files' => [],
     ];
@@ -92,7 +92,7 @@ foreach ($issues as $issue) {
     }
 
     $response = $client->post(
-        'https://api.github.com/repos/doctrine/' . $githubRepository . '/issues/' . $issueMap[$issue] . '/comments',
+        'https://api.github.com/repos/' . getenv('GITHUB_ORG') . '/' . $githubRepository . '/issues/' . $issueMap[$issue] . '/comments',
         $githubHeaders,
         json_encode(['body' => $comment])
     );

--- a/export_jira_tickets.php
+++ b/export_jira_tickets.php
@@ -113,21 +113,6 @@ while (true) {
 
         $import['comments'] = [];
 
-        if (isset($issue['fields']['issuelinks']) && $issue['fields']['issuelinks']) {
-            $comment = "";
-            foreach ($issue['fields']['issuelinks'] as $link) {
-                /*if (isset($link['inwardIssue'])) {
-                    $comment .= sprintf("* %s [%s: %s](http://www.doctrine-project.org/jira/browse/%s)\n", $link['type']['inward'], $link['inwardIssue']['key'], $link['inwardIssue']['fields']['summary'], $link['inwardIssue']['key']);
-                } else if (isset($link['outwardIssue'])) {
-                    $comment .= sprintf("* %s [%s: %s](http://www.doctrine-project.org/jira/browse/%s)\n", $link['type']['outward'], $link['outwardIssue']['key'], $link['outwardIssue']['fields']['summary'], $link['outwardIssue']['key']);
-                }*/
-            }
-            $import['comments'][] = [
-                'body' => $comment,
-                'created_at' => substr($issue['fields']['created'], 0, 19) . 'Z',
-            ];
-        }
-
         if (isset($issue['fields']['comment']) && count($issue['fields']['comment']['comments']) > 0) {
             foreach ($issue['fields']['comment']['comments'] as $comment) {
                 $import['comments'][] = [

--- a/generate_issues_map.php
+++ b/generate_issues_map.php
@@ -1,8 +1,12 @@
 <?php
 
 $issueMap = [];
-foreach (['DBAL', 'DDC', 'DCOM'] as $project) {
+
+
+$projectIds = array_keys(json_decode(getenv('PROJECTS'), true));
+
+foreach ($projectIds as $project) {
     $issueMap = array_merge($issueMap, json_decode(file_get_contents('data/' . $project . '.issues.json'), true));
 }
 
-file_put_contents('data/issues.json', json_encode(['doctrine_issue_map' => $issueMap], JSON_PRETTY_PRINT));
+file_put_contents('data/issues.json', json_encode([getenv('GITHUB_ORG') . '_issue_map' => $issueMap], JSON_PRETTY_PRINT));

--- a/import_tickets.php
+++ b/import_tickets.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Doctrine Jira to Github Migration
+ * Jira to Github Migration
  *
  * @example
  *
@@ -29,11 +29,11 @@ if (!isset($projects[$project])) {
 
 $githubRepository = $projects[$project];
 $githubHeaders = [
-    'User-Agent: Doctrine Jira Migration',
-    'Authorization: token ' . $_SERVER['GITHUB_TOKEN'],
+    'User-Agent: ' . getenv('GITHUB_ORG') . ' Jira Migration',
+    'Authorization: token ' . getenv('GITHUB_TOKEN'),
     'Accept: application/vnd.github.golden-comet-preview+json'
 ];
-$jiraHeaders = ['Authorization: Basic ' . base64_encode(sprintf('%s:%s', $_SERVER['JIRA_USER'], $_SERVER['JIRA_PASSWORD']))];
+$jiraHeaders = ['Authorization: Basic ' . base64_encode(sprintf('%s:%s', getenv('JIRA_USER'), getenv('JIRA_TOKEN')))];
 
 $ticketStatus = [];
 if (file_exists('data/' . $project . '.status.json')) {
@@ -84,7 +84,7 @@ foreach ($files as $file) {
     }
     //printf("debug skip\n"); continue;
 
-    $response = $client->post('https://api.github.com/repos/doctrine/' . $githubRepository . '/import/issues', $githubHeaders, json_encode($issue));
+    $response = $client->post('https://api.github.com/repos/' . getenv('GITHUB_ORG') . '/' . $githubRepository . '/import/issues', $githubHeaders, json_encode($issue));
 
     if ($response->getStatusCode() >= 400) {
         printf("Error: " . $response->getContent());

--- a/issue_numbers.php
+++ b/issue_numbers.php
@@ -22,15 +22,15 @@ if (!isset($projects[$project])) {
 
 $githubRepository = $projects[$project];
 $githubHeaders = [
-    'User-Agent: Doctrine Jira Migration',
-    'Authorization: token ' . $_SERVER['GITHUB_TOKEN'],
+    'User-Agent: ' . getenv('GITHUB_ORG') . ' Jira Migration',
+    'Authorization: token ' . getenv('GITHUB_TOKEN'),
     'Accept: application/vnd.github.golden-comet-preview+json'
 ];
 
 $page = 1;
 $numbers = [];
 while (true) {
-    $response = $client->get('https://api.github.com/repos/doctrine/' . $githubRepository . '/issues?state=all&page=' . $page, $githubHeaders);
+    $response = $client->get('https://api.github.com/repos/' . getenv('GITHUB_ORG') . '/' . $githubRepository . '/issues?state=all&page=' . $page, $githubHeaders);
 
     if ($response->getStatusCode() != 200) {
         exit;
@@ -44,7 +44,11 @@ while (true) {
     }
 
     foreach ($issues as $issue) {
-        if ($issue['user']['login'] != $_SERVER['GITHUB_USERNAME']) {
+        if ($issue['user']['login'] != getenv('GITHUB_USERNAME')) {
+            continue;
+        }
+
+        if (strrpos($issue['title'], ':') === false) {
             continue;
         }
 

--- a/projects.php
+++ b/projects.php
@@ -1,8 +1,8 @@
 <?php
 
-return [
-    'DDC' => 'doctrine2',
-    'DBAL' => 'dbal',
-    'DMIG' => 'migrations',
-    'DCOM' => 'common',
-];
+require_once 'vendor/autoload.php';
+
+$dotenv = new Dotenv\Dotenv(__DIR__);
+$dotenv->load();
+
+return json_decode(getenv('PROJECTS'), true);


### PR DESCRIPTION
These changes allows to define all relevant mappings in the `.env` instead of information being hardcoded in the scripts, or as inline associative arrays. It has been tested to move ~500 JIRA issues to GitHub Issues.